### PR TITLE
External allocator support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ perf.data
 doc/
 .dub/
 test/compile_test
+test/external_allocator_test

--- a/src/containers/dynamicarray.d
+++ b/src/containers/dynamicarray.d
@@ -9,8 +9,8 @@ module containers.dynamicarray;
 
 /**
  * Array that is able to grow itself when items are appended to it. Uses
- * reference counting to manage memory and malloc/free/realloc for managing its
- * storage.
+ * malloc/free/realloc to manage its storage.
+ *
  * Params:
  *     T = the array element type
  *     supportGC = true if the container should support holding references to

--- a/src/containers/dynamicarray.d
+++ b/src/containers/dynamicarray.d
@@ -8,7 +8,6 @@
 module containers.dynamicarray;
 
 private import std.experimental.allocator.mallocator : Mallocator;
-private import std.experimental.allocator.common : stateSize;
 
 /**
  * Array that is able to grow itself when items are appended to it. Uses
@@ -21,8 +20,9 @@ private import std.experimental.allocator.common : stateSize;
  */
 struct DynamicArray(T, Allocator = Mallocator, bool supportGC = true)
 {
-	import std.traits : hasMember;
 	this(this) @disable;
+
+	private import std.experimental.allocator.common : stateSize;
 
 	static if (stateSize!Allocator != 0)
 	{
@@ -185,12 +185,9 @@ private:
 
 	import containers.internal.storage_type : ContainerStorageType;
 	import containers.internal.element_type : ContainerElementType;
+	private import containers.internal.mixins : AllocatorState;
 
-	static if (stateSize!Allocator == 0)
-		alias allocator = Allocator.instance;
-	else
-		Allocator allocator;
-
+	mixin AllocatorState!Allocator;
 	ContainerStorageType!(T)[] arr;
 	size_t l;
 }

--- a/src/containers/dynamicarray.d
+++ b/src/containers/dynamicarray.d
@@ -66,13 +66,14 @@ struct DynamicArray(T, Allocator = Mallocator, bool supportGC = true)
 	}
 
 	/// Slice operator overload
+	pragma(inline, true)
 	auto opSlice(this This)() @nogc
 	{
-		alias ET = ContainerElementType!(This, T);
-		return cast(ET[]) arr[0 .. l];
+		return opSlice!(This)(0, l);
 	}
 
 	/// ditto
+	pragma(inline, true)
 	auto opSlice(this This)(size_t a, size_t b) @nogc
 	{
 		alias ET = ContainerElementType!(This, T);
@@ -80,10 +81,10 @@ struct DynamicArray(T, Allocator = Mallocator, bool supportGC = true)
 	}
 
 	/// Index operator overload
+	pragma(inline, true)
 	auto opIndex(this This)(size_t i) @nogc
 	{
-		alias ET = ContainerElementType!(This, T);
-		return cast(ET) arr[i];
+		return opSlice!(This)(i, i + 1)[0];
 	}
 
 	/**

--- a/src/containers/hashmap.d
+++ b/src/containers/hashmap.d
@@ -10,7 +10,6 @@ module containers.hashmap;
 private import containers.internal.hash : generateHash;
 private import containers.internal.node : shouldAddGCRange;
 private import std.experimental.allocator.mallocator : Mallocator;
-private import std.experimental.allocator.common : stateSize;
 
 /**
  * Associative array / hash map.
@@ -24,9 +23,10 @@ struct HashMap(K, V, Allocator = Mallocator, alias hashFunction = generateHash!K
 {
 	this(this) @disable;
 
+	private import std.experimental.allocator.common : stateSize;
+
 	static if (stateSize!Allocator != 0)
 	{
-		/// No default construction if an allocator must be provided.
 		this() @disable;
 
 		/**
@@ -242,6 +242,7 @@ private:
 	import containers.unrolledlist : UnrolledList;
 	import containers.internal.storage_type : ContainerStorageType;
 	import containers.internal.element_type : ContainerElementType;
+	import containers.internal.mixins : AllocatorState;
 	import core.memory : GC;
 
 	enum bool storeHash = !isBasicType!K;
@@ -396,11 +397,7 @@ private:
 		ContainerStorageType!V value;
 	}
 
-	static if (stateSize!Allocator == 0)
-		alias allocator = Allocator.instance;
-	else
-		Allocator allocator;
-
+	mixin AllocatorState!Allocator;
 	alias Bucket = UnrolledList!(Node, Allocator, supportGC);
 	Bucket[] buckets;
 	size_t _length;

--- a/src/containers/hashmap.d
+++ b/src/containers/hashmap.d
@@ -7,8 +7,10 @@
 
 module containers.hashmap;
 
-import containers.internal.hash : generateHash;
-import containers.internal.node : shouldAddGCRange;
+private import containers.internal.hash : generateHash;
+private import containers.internal.node : shouldAddGCRange;
+private import std.experimental.allocator.mallocator : Mallocator;
+private import std.experimental.allocator.common : stateSize;
 
 /**
  * Associative array / hash map.
@@ -17,34 +19,73 @@ import containers.internal.node : shouldAddGCRange;
  *     V = the value type
  *     hashFunction = the hash function to use on the keys
  */
-struct HashMap(K, V, alias hashFunction = generateHash!K,
+struct HashMap(K, V, Allocator = Mallocator, alias hashFunction = generateHash!K,
 	bool supportGC = shouldAddGCRange!K || shouldAddGCRange!V)
 {
 	this(this) @disable;
 
-	/**
-	 * Constructs an HashMap with an initial bucket count of bucketCount. bucketCount
-	 * must be a power of two.
-	 */
-	this(size_t bucketCount)
-	in
+	static if (stateSize!Allocator != 0)
 	{
-		assert ((bucketCount & (bucketCount - 1)) == 0, "bucketCount must be a power of two");
+		/// No default construction if an allocator must be provided.
+		this() @disable;
+
+		/**
+		 * Use the given `allocator` for allocations.
+		 */
+		this(Allocator allocator)
+		in
+		{
+			assert(allocator !is null, "Allocator must not be null");
+		}
+		body
+		{
+			this.allocator = allocator;
+		}
+
+		/**
+		 * Constructs an HashMap with an initial bucket count of bucketCount. bucketCount
+		 * must be a power of two.
+		 */
+		this(size_t bucketCount, Allocator allocator)
+		in
+		{
+			assert(allocator !is null, "Allocator must not be null");
+			assert((bucketCount & (bucketCount - 1)) == 0, "bucketCount must be a power of two");
+		}
+		body
+		{
+			this.allocator = allocator;
+			initialize(bucketCount);
+		}
+
+		invariant
+		{
+			assert(allocator !is null);
+		}
 	}
-	body
+	else
 	{
-		initialize(bucketCount);
+		/**
+		 * Constructs an HashMap with an initial bucket count of bucketCount. bucketCount
+		 * must be a power of two.
+		 */
+		this(size_t bucketCount)
+		in
+		{
+			assert((bucketCount & (bucketCount - 1)) == 0, "bucketCount must be a power of two");
+		}
+		body
+		{
+			initialize(bucketCount);
+		}
 	}
 
 	~this()
 	{
-		import std.experimental.allocator.mallocator : Mallocator;
 		import std.experimental.allocator : dispose;
-		foreach (ref bucket; buckets)
-			typeid(typeof(bucket)).destroy(&bucket);
 		static if (supportGC)
 			GC.removeRange(buckets.ptr);
-		Mallocator.instance.dispose(buckets);
+		allocator.dispose(buckets);
 	}
 
 	/**
@@ -196,7 +237,6 @@ struct HashMap(K, V, alias hashFunction = generateHash!K,
 
 private:
 
-	import std.experimental.allocator.mallocator : Mallocator;
 	import std.experimental.allocator : make;
 	import std.traits : isBasicType;
 	import containers.unrolledlist : UnrolledList;
@@ -209,14 +249,17 @@ private:
 	void initialize(size_t bucketCount = 4)
 	{
 		import std.conv : emplace;
-		import std.experimental.allocator.mallocator : Mallocator;
-		buckets = (cast(Bucket*) Mallocator.instance.allocate(
-			bucketCount * Bucket.sizeof))[0 .. bucketCount];
-		assert (buckets.length == bucketCount);
+
+		buckets = (cast(Bucket*) allocator.allocate(bucketCount * Bucket.sizeof))[0 .. bucketCount];
 		static if (supportGC)
 			GC.addRange(buckets.ptr, buckets.length * Bucket.sizeof);
 		foreach (ref bucket; buckets)
-			emplace(&bucket);
+		{
+			static if (stateSize!Allocator == 0)
+				emplace(&bucket);
+			else
+				emplace(&bucket, allocator);
+		}
 	}
 
 	void insert(K key, V value)
@@ -267,19 +310,24 @@ private:
 	void rehash() @trusted
 	{
 //		import std.experimental.allocator : make, dispose;
-		import std.experimental.allocator.mallocator : Mallocator;
 		import std.conv : emplace;
 		immutable size_t newLength = buckets.length << 1;
 		immutable size_t newSize = newLength * Bucket.sizeof;
 		Bucket[] oldBuckets = buckets;
 		assert (oldBuckets.ptr == buckets.ptr);
-		buckets = cast(Bucket[]) Mallocator.instance.allocate(newSize);
+		buckets = cast(Bucket[]) allocator.allocate(newSize);
 		static if (supportGC)
 			GC.addRange(buckets.ptr, buckets.length * Bucket.sizeof);
 		assert (buckets);
 		assert (buckets.length == newLength);
 		foreach (ref bucket; buckets)
-			emplace(&bucket);
+		{
+			static if (stateSize!Allocator == 0)
+				emplace(&bucket);
+			else
+				emplace(&bucket, allocator);
+		}
+
 		foreach (ref bucket; oldBuckets)
 		{
 			foreach (node; bucket.range)
@@ -300,7 +348,7 @@ private:
 		}
 		static if (supportGC)
 			GC.removeRange(oldBuckets.ptr);
-		Mallocator.instance.deallocate(cast(void[]) oldBuckets);
+		allocator.deallocate(cast(void[]) oldBuckets);
 	}
 
 	size_t hashToIndex(size_t hash) const pure nothrow @safe @nogc
@@ -348,7 +396,12 @@ private:
 		ContainerStorageType!V value;
 	}
 
-	alias Bucket = UnrolledList!(Node, supportGC);
+	static if (stateSize!Allocator == 0)
+		alias allocator = Allocator.instance;
+	else
+		Allocator allocator;
+
+	alias Bucket = UnrolledList!(Node, Allocator, supportGC);
 	Bucket[] buckets;
 	size_t _length;
 }

--- a/src/containers/hashset.d
+++ b/src/containers/hashset.d
@@ -10,7 +10,6 @@ module containers.hashset;
 private import containers.internal.hash : generateHash;
 private import containers.internal.node : shouldAddGCRange;
 private import std.experimental.allocator.mallocator : Mallocator;
-private import std.experimental.allocator.common : stateSize;
 
 /**
  * Hash Set.
@@ -23,9 +22,10 @@ struct HashSet(T, Allocator = Mallocator, alias hashFunction = generateHash!T,
 {
 	this(this) @disable;
 
+	private import std.experimental.allocator.common : stateSize;
+
 	static if (stateSize!Allocator != 0)
 	{
-		/// No default construction if an allocator must be provided.
 		this() @disable;
 
 		/**
@@ -40,6 +40,7 @@ struct HashSet(T, Allocator = Mallocator, alias hashFunction = generateHash!T,
 		{
 			this.allocator = allocator;
 		}
+
 		/**
 		 * Constructs a HashSet with an initial bucket count of bucketCount.
 		 * bucketCount must be a power of two.
@@ -190,6 +191,7 @@ private:
 	import containers.internal.node : shouldAddGCRange, fatNodeCapacity;
 	import containers.internal.storage_type : ContainerStorageType;
 	import containers.internal.element_type : ContainerElementType;
+	import containers.internal.mixins : AllocatorState;
 	import containers.unrolledlist : UnrolledList;
 	import std.traits : isBasicType, isPointer;
 
@@ -514,11 +516,7 @@ private:
 		}
 
 		BucketNode* root;
-
-		static if (stateSize!Allocator == 0)
-			alias allocator = Allocator.instance;
-		else
-			Allocator allocator;
+		mixin AllocatorState!Allocator;
 	}
 
 	static struct ItemNode
@@ -547,11 +545,7 @@ private:
 		ContainerStorageType!T value;
 	}
 
-	static if (stateSize!Allocator == 0)
-		alias allocator = Allocator.instance;
-	else
-		Allocator allocator;
-
+	mixin AllocatorState!Allocator;
 	Bucket[] buckets;
 	size_t _length;
 }

--- a/src/containers/immutablehashset.d
+++ b/src/containers/immutablehashset.d
@@ -12,7 +12,8 @@ module containers.immutablehashset;
  * supports quickly determining if an element is present.
  *
  * Because the set does not support inserting, it only takes up as much memory
- * as is necessary to contain the elements provided at construction.
+ * as is necessary to contain the elements provided at construction. Memory is
+ * managed my malloc/free.
  */
 struct ImmutableHashSet(T, alias hashFunction)
 {

--- a/src/containers/internal/mixins.d
+++ b/src/containers/internal/mixins.d
@@ -1,0 +1,15 @@
+/**
+ * Container mixins
+ * Copyright: © 2015 Economic Modeling Specialists, Intl.
+ * Authors: Brian Schott
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ */
+module containers.internal.mixins;
+
+mixin template AllocatorState(Allocator)
+{
+	static if (stateSize!Allocator == 0)
+		alias allocator = Allocator.instance;
+	else
+		Allocator allocator;
+}

--- a/src/containers/openhashset.d
+++ b/src/containers/openhashset.d
@@ -32,7 +32,6 @@ struct OpenHashSet(T, Allocator = Mallocator,
 
 	static if (stateSize!Allocator != 0)
 	{
-		/// No default construction if an allocator must be provided.
 		this() @disable;
 
 		/**
@@ -208,6 +207,7 @@ private:
 
 	import containers.internal.storage_type : ContainerStorageType;
 	import containers.internal.element_type : ContainerElementType;
+	import containers.internal.mixins : AllocatorState;
 	import core.memory : GC;
 
 	enum DEFAULT_INITIAL_CAPACITY = 8;
@@ -278,7 +278,7 @@ private:
 
 	/**
 	 * Returns:
-	 *     size_t.max if the
+	 *     size_t.max if the item was not found
 	 */
 	static size_t toIndex(const Node[] n, T item, size_t hash) nothrow @safe
 	{
@@ -296,11 +296,7 @@ private:
 
 	Node[] nodes;
 	size_t _length;
-
-	static if (stateSize!Allocator == 0)
-		alias allocator = Allocator.instance;
-	else
-		Allocator allocator;
+	mixin AllocatorState!Allocator;
 
 	struct Node
 	{

--- a/src/containers/openhashset.d
+++ b/src/containers/openhashset.d
@@ -6,8 +6,10 @@
  */
 module containers.openhashset;
 
-import containers.internal.hash : generateHash;
-import containers.internal.node : shouldAddGCRange;
+private import containers.internal.hash : generateHash;
+private import containers.internal.node : shouldAddGCRange;
+private import std.experimental.allocator.mallocator : Mallocator;
+private import std.experimental.allocator.common : stateSize;
 
 /**
  * Simple open-addressed hash set. Use this instead of HashSet when the size and
@@ -20,36 +22,74 @@ import containers.internal.node : shouldAddGCRange;
  *         to ensure that the GC does not accidentally free memory owned by this
  *         container.
  */
-struct OpenHashSet(T, alias hashFunction = generateHash!T, bool supportGC = shouldAddGCRange!T)
+struct OpenHashSet(T, Allocator = Mallocator,
+	alias hashFunction = generateHash!T, bool supportGC = shouldAddGCRange!T)
 {
 	/**
 	 * Disallow copy construction
 	 */
 	this(this) @disable;
 
-	/**
-	 * Initializes the hash set with the given initial capacity.
-	 *
-	 * Params:
-	 *     initialCapacity = the initial capacity for the hash set
-	 */
-	this(size_t initialCapacity)
-	in
+	static if (stateSize!Allocator != 0)
 	{
-		assert ((initialCapacity & initialCapacity - 1) == 0, "initialCapacity must be a power of 2");
+		/// No default construction if an allocator must be provided.
+		this() @disable;
+
+		/**
+		 * Use the given `allocator` for allocations.
+		 */
+		this(Allocator allocator)
+		in
+		{
+			assert(allocator !is null, "Allocator must not be null");
+		}
+		body
+		{
+			this.allocator = allocator;
+		}
+
+		/**
+		 * Initializes the hash set with the given initial capacity.
+		 *
+		 * Params:
+		 *     initialCapacity = the initial capacity for the hash set
+		 */
+		this(size_t initialCapacity, Allocator allocator)
+		in
+		{
+			assert(allocator !is null, "Allocator must not be null");
+			assert ((initialCapacity & initialCapacity - 1) == 0, "initialCapacity must be a power of 2");
+		}
+		body
+		{
+			this.allocator = allocator;
+			initialize(initialCapacity);
+		}
 	}
-	body
+	else
 	{
-		initialize(initialCapacity);
+		/**
+		 * Initializes the hash set with the given initial capacity.
+		 *
+		 * Params:
+		 *     initialCapacity = the initial capacity for the hash set
+		 */
+		this(size_t initialCapacity)
+		in
+		{
+			assert ((initialCapacity & initialCapacity - 1) == 0, "initialCapacity must be a power of 2");
+		}
+		body
+		{
+			initialize(initialCapacity);
+		}
 	}
 
 	~this()
 	{
-		foreach (ref node; nodes)
-			typeid(typeof(node)).destroy(&node);
 		static if (supportGC)
 			GC.removeRange(nodes.ptr);
-		Mallocator.instance.deallocate(nodes);
+		allocator.deallocate(nodes);
 	}
 
 	/**
@@ -168,7 +208,6 @@ private:
 
 	import containers.internal.storage_type : ContainerStorageType;
 	import containers.internal.element_type : ContainerElementType;
-	import std.experimental.allocator.mallocator : Mallocator;
 	import core.memory : GC;
 
 	enum DEFAULT_INITIAL_CAPACITY = 8;
@@ -214,7 +253,7 @@ private:
 	void grow()
 	{
 		immutable size_t newCapacity = nodes.length << 1;
-		Node[] newNodes = (cast (Node*) Mallocator.instance.allocate(newCapacity * Node.sizeof))
+		Node[] newNodes = (cast (Node*) allocator.allocate(newCapacity * Node.sizeof))
 			[0 .. newCapacity];
 		newNodes[] = Node.init;
 		static if (supportGC)
@@ -226,14 +265,13 @@ private:
 		}
 		static if (supportGC)
 			GC.removeRange(nodes.ptr);
-		Mallocator.instance.deallocate(nodes);
+		allocator.deallocate(nodes);
 		nodes = newNodes;
 	}
 
 	void initialize(size_t nodeCount)
 	{
-		nodes = (cast (Node*) Mallocator.instance.allocate(nodeCount * Node.sizeof))
-			[0 .. nodeCount];
+		nodes = (cast (Node*) allocator.allocate(nodeCount * Node.sizeof))[0 .. nodeCount];
 		nodes[] = Node.init;
 		_length = 0;
 	}
@@ -258,6 +296,11 @@ private:
 
 	Node[] nodes;
 	size_t _length;
+
+	static if (stateSize!Allocator == 0)
+		alias allocator = Allocator.instance;
+	else
+		Allocator allocator;
 
 	struct Node
 	{

--- a/src/containers/simdset.d
+++ b/src/containers/simdset.d
@@ -7,7 +7,6 @@
 module containers.simdset;
 
 private import std.experimental.allocator.mallocator : Mallocator;
-private import std.experimental.allocator.common : stateSize;
 
 /**
  * Set implementation that is well suited for small sets and simple items.
@@ -22,6 +21,8 @@ version (D_InlineAsm_X86_64) struct SimdSet(T, Allocator = Mallocator)
 	if (T.sizeof == 1 || T.sizeof == 2 || T.sizeof == 4 || T.sizeof == 8)
 {
 	this(this) @disable;
+
+	private import std.experimental.allocator.common : stateSize;
 
 	static if (stateSize!Allocator != 0)
 	{
@@ -154,6 +155,7 @@ version (D_InlineAsm_X86_64) struct SimdSet(T, Allocator = Mallocator)
 private:
 
 	import containers.internal.storage_type : ContainerStorageType;
+	private import containers.internal.mixins : AllocatorState;
 
 	static string asmSearch()
 	{
@@ -206,11 +208,7 @@ private:
 		}`.format(instruction);
 	}
 
-	static if (stateSize!Allocator == 0)
-		alias allocator = Allocator.instance;
-	else
-		Allocator allocator;
-
+	mixin AllocatorState!Allocator;
 	ContainerStorageType!(T)[] storage;
 	size_t _length;
 }

--- a/src/containers/slist.d
+++ b/src/containers/slist.d
@@ -8,7 +8,6 @@
 module containers.slist;
 
 private import std.experimental.allocator.mallocator : Mallocator;
-private import std.experimental.allocator.common : stateSize;
 
 /**
  * Single-linked allocator-backed list.
@@ -20,6 +19,8 @@ struct SList(T, Allocator = Mallocator)
 {
 	/// Disable copying.
 	this(this) @disable;
+
+	private import std.experimental.allocator.common : stateSize;
 
 	static if (stateSize!Allocator != 0)
 	{
@@ -224,6 +225,7 @@ private:
 	import std.experimental.allocator : make, dispose;
 	import containers.internal.node : shouldAddGCRange;
 	import containers.internal.element_type : ContainerElementType;
+	import containers.internal.mixins : AllocatorState;
 
 	static struct Range(ThisT)
 	{
@@ -254,13 +256,8 @@ private:
 		T value;
 	}
 
-	static if (stateSize!Allocator == 0)
-		alias allocator = Allocator.instance;
-	else
-		Allocator allocator;
-
+	mixin AllocatorState!Allocator;
 	Node* _front;
-
 	size_t _length;
 }
 

--- a/src/containers/treemap.d
+++ b/src/containers/treemap.d
@@ -8,6 +8,7 @@
 module containers.treemap;
 
 import std.experimental.allocator.mallocator : Mallocator;
+import std.experimental.allocator.common : stateSize;
 
 /**
  * A key→value mapping where the keys are guaranteed to be sorted.
@@ -24,12 +25,28 @@ struct TreeMap(K, V, Allocator = Mallocator, alias less = "a < b",
 
 	this(this) @disable;
 
-	/// Supports $(B treeMap[key] = value;) syntax.
-	void opIndexAssign(V value, K key)
+	static if (stateSize!Allocator != 0)
+	{
+		/**
+		 * Use the given `allocator` for allocations.
+		 */
+		this(Allocator allocator)
+		{
+			tree = TreeType(allocator);
+		}
+	}
+
+	/**
+	 * Inserts the given key-value pair.
+	 */
+	void insert(V value, K key)
 	{
 		auto tme = TreeMapElement(key, value);
 		tree.insert(tme);
 	}
+
+	/// Supports $(B treeMap[key] = value;) syntax.
+	alias opIndexAssign = insert;
 
 	/// Supports $(B treeMap[key]) syntax.
 	auto opIndex(this This)(K key) const
@@ -98,7 +115,12 @@ private:
 			return binaryFun!less(key, other.key);
 		}
 	}
-	TTree!(TreeMapElement, Allocator, false, "a.opCmp(b) > 0", supportGC, cacheLineSize) tree;
+
+	alias TreeType = TTree!(TreeMapElement, Allocator, false, "a.opCmp(b) > 0", supportGC, cacheLineSize);
+	static if (stateSize!Allocator == 0)
+		TreeType tree = void;
+	else
+		TreeType tree;
 }
 
 unittest
@@ -108,4 +130,24 @@ unittest
 	tm["test2"] = "world";
 	tm.remove("test1");
 	tm.remove("test2");
+}
+
+unittest
+{
+	import std.experimental.allocator.building_blocks.free_list : FreeList;
+	import std.experimental.allocator.building_blocks.allocator_list : AllocatorList;
+	import std.experimental.allocator.building_blocks.region : Region;
+	import std.experimental.allocator.building_blocks.stats_collector : StatsCollector;
+	import std.stdio : stdout;
+	import std.algorithm.iteration : walkLength;
+
+	StatsCollector!(FreeList!(AllocatorList!(a => Region!(Mallocator)(1024 * 1024)),
+		64)) allocator;
+	auto intMap = TreeMap!(int, int, typeof(&allocator))(&allocator);
+	foreach (i; 0 .. 10_000)
+		intMap[i] = 10_000 - i;
+	assert(intMap.length == 10_000);
+	destroy(intMap);
+	assert(allocator.numAllocate == allocator.numDeallocate);
+	assert(allocator.bytesUsed == 0);
 }

--- a/src/containers/treemap.d
+++ b/src/containers/treemap.d
@@ -7,8 +7,8 @@
 
 module containers.treemap;
 
-import std.experimental.allocator.mallocator : Mallocator;
-import std.experimental.allocator.common : stateSize;
+private import std.experimental.allocator.mallocator : Mallocator;
+private import std.experimental.allocator.common : stateSize;
 
 /**
  * A key→value mapping where the keys are guaranteed to be sorted.
@@ -27,6 +27,9 @@ struct TreeMap(K, V, Allocator = Mallocator, alias less = "a < b",
 
 	static if (stateSize!Allocator != 0)
 	{
+		/// No default construction if an allocator must be provided.
+		this() @disable;
+
 		/**
 		 * Use the given `allocator` for allocations.
 		 */
@@ -143,11 +146,12 @@ unittest
 
 	StatsCollector!(FreeList!(AllocatorList!(a => Region!(Mallocator)(1024 * 1024)),
 		64)) allocator;
-	auto intMap = TreeMap!(int, int, typeof(&allocator))(&allocator);
-	foreach (i; 0 .. 10_000)
-		intMap[i] = 10_000 - i;
-	assert(intMap.length == 10_000);
-	destroy(intMap);
+	{
+		auto intMap = TreeMap!(int, int, typeof(&allocator))(&allocator);
+		foreach (i; 0 .. 10_000)
+			intMap[i] = 10_000 - i;
+		assert(intMap.length == 10_000);
+	}
 	assert(allocator.numAllocate == allocator.numDeallocate);
 	assert(allocator.bytesUsed == 0);
 }

--- a/src/containers/treemap.d
+++ b/src/containers/treemap.d
@@ -7,6 +7,8 @@
 
 module containers.treemap;
 
+import std.experimental.allocator.mallocator : Mallocator;
+
 /**
  * A key→value mapping where the keys are guaranteed to be sorted.
  * Params:
@@ -16,8 +18,8 @@ module containers.treemap;
  *     supportGC = true to support storing GC-allocated objects, false otherwise
  *     cacheLineSize = the size of the internal nodes in bytes
  */
-struct TreeMap(K, V, alias less = "a < b", bool supportGC = true,
-	size_t cacheLineSize = 64)
+struct TreeMap(K, V, Allocator = Mallocator, alias less = "a < b",
+	bool supportGC = true, size_t cacheLineSize = 64)
 {
 
 	this(this) @disable;
@@ -96,7 +98,7 @@ private:
 			return binaryFun!less(key, other.key);
 		}
 	}
-	TTree!(TreeMapElement, false, "a.opCmp(b) > 0", supportGC, cacheLineSize) tree;
+	TTree!(TreeMapElement, Allocator, false, "a.opCmp(b) > 0", supportGC, cacheLineSize) tree;
 }
 
 unittest

--- a/src/containers/ttree.d
+++ b/src/containers/ttree.d
@@ -54,7 +54,7 @@ struct TTree(T, Allocator = Mallocator, bool allowDuplicates = false,
 		deallocateNode(root, allocator);
 	}
 
-	enum size_t nodeCapacity = fatNodeCapacity!(T.sizeof, 3, size_t, cacheLineSize);
+	private enum size_t nodeCapacity = fatNodeCapacity!(T.sizeof, 3, size_t, cacheLineSize);
 	static assert (nodeCapacity <= (size_t.sizeof * 4), "cannot fit height info and registry in size_t");
 
 	debug(EMSI_CONTAINERS) invariant()
@@ -540,7 +540,7 @@ private:
 					calcHeight();
 					return true;
 				}
-				bool b = left.insert(value, root, allocator);
+				immutable bool b = left.insert(value, root, allocator);
 				if (imbalanced() == -1)
 					rotateRight(root, allocator);
 				calcHeight();
@@ -554,7 +554,7 @@ private:
 					calcHeight();
 					return true;
 				}
-				bool b = right.insert(value, root, allocator);
+				immutable bool b = right.insert(value, root, allocator);
 				if (imbalanced() == 1)
 					rotateLeft(root, allocator);
 				calcHeight();
@@ -582,14 +582,14 @@ private:
 			if (right.height < left.height)
 			{
 				values[] = temp[0 .. $ - 1];
-				bool b = right.insert(temp[$ - 1], root, allocator);
+				immutable bool b = right.insert(temp[$ - 1], root, allocator);
 				if (imbalanced() == 1)
 					rotateLeft(root, allocator);
 				calcHeight();
 				return b;
 			}
 			values[] = temp[1 .. $];
-			bool b = left.insert(temp[0], root, allocator);
+			immutable bool b = left.insert(temp[0], root, allocator);
 			if (imbalanced() == -1)
 				rotateRight(root, allocator);
 			calcHeight();
@@ -603,14 +603,14 @@ private:
 			assert (!isEmpty());
 			if (isFull() && _less(value, values[0]))
 			{
-				bool r = left !is null && left.remove(value, left, allocator, cleanup);
+				immutable bool r = left !is null && left.remove(value, left, allocator, cleanup);
 				if (left.isEmpty())
 					deallocateNode(left, allocator);
 				return r;
 			}
 			if (isFull() && _less(values[$ - 1], value))
 			{
-				bool r = right !is null && right.remove(value, right, allocator, cleanup);
+				immutable bool r = right !is null && right.remove(value, right, allocator, cleanup);
 				if (right.isEmpty())
 					deallocateNode(right, allocator);
 				return r;

--- a/src/containers/ttree.d
+++ b/src/containers/ttree.d
@@ -7,6 +7,7 @@
 
 module containers.ttree;
 
+import std.experimental.allocator.mallocator : Mallocator;
 import std.range : ElementType, isInputRange;
 
 /**
@@ -26,19 +27,32 @@ import std.range : ElementType, isInputRange;
  *         GC-allocated memory.
  * See_also: $(LINK http://en.wikipedia.org/wiki/T-tree)
  */
-struct TTree(T, bool allowDuplicates = false, alias less = "a < b",
-	bool supportGC = true, size_t cacheLineSize = 64)
+struct TTree(T, Allocator = Mallocator, bool allowDuplicates = false,
+	alias less = "a < b", bool supportGC = true, size_t cacheLineSize = 64)
 {
 	this(this) @disable;
+
+	static if (stateSize!Allocator != 0)
+	{
+		/**
+		 * Use `allocator` to allocate and free nodes in the tree.
+		 */
+		this(Allocator allocator)
+		{
+			this.allocator = allocator;
+		}
+
+		private alias AllocatorType = Allocator;
+	}
+	else
+		alias AllocatorType = void*;
 
 	~this()
 	{
 		if (root is null)
 			return;
-		deallocateNode(root);
+		deallocateNode(root, allocator);
 	}
-
-	private import containers.internal.storage_type : ContainerStorageType;
 
 	enum size_t nodeCapacity = fatNodeCapacity!(T.sizeof, 3, size_t, cacheLineSize);
 	static assert (nodeCapacity <= (size_t.sizeof * 4), "cannot fit height info and registry in size_t");
@@ -66,11 +80,11 @@ struct TTree(T, bool allowDuplicates = false, alias less = "a < b",
 	{
 		if (root is null)
 		{
-			root = allocateNode(cast(Value) value, null);
+			root = allocateNode(cast(Value) value, null, allocator);
 			++_length;
 			return true;
 		}
-		immutable bool r = root.insert(cast(Value) value, root);
+		immutable bool r = root.insert(cast(Value) value, root, allocator);
 		if (r)
 			++_length;
 		return r;
@@ -108,11 +122,11 @@ struct TTree(T, bool allowDuplicates = false, alias less = "a < b",
 	 */
 	bool remove(T value, void delegate(T) cleanup = null)
 	{
-		bool removed = root !is null && root.remove(cast(Value) value, root, cleanup);
+		bool removed = root !is null && root.remove(cast(Value) value, root, allocator, cleanup);
 		if (removed)
 			--_length;
 		if (_length == 0)
-			deallocateNode(root);
+			deallocateNode(root, allocator);
 		return removed;
 	}
 
@@ -352,9 +366,11 @@ struct TTree(T, bool allowDuplicates = false, alias less = "a < b",
 
 private:
 
-	import containers.internal.node : fatNodeCapacity, fullBits, shouldAddGCRange, shouldNullSlot;
 	import containers.internal.element_type : ContainerElementType;
+	import containers.internal.node : fatNodeCapacity, fullBits, shouldAddGCRange, shouldNullSlot;
+	import containers.internal.storage_type : ContainerStorageType;
 	import std.algorithm : sort;
+	import std.experimental.allocator.common : stateSize;
 	import std.functional: binaryFun;
 	import std.traits: isPointer, PointerTarget;
 
@@ -367,7 +383,7 @@ private:
 	else
 		alias _less = binaryFun!less;
 
-	static Node* allocateNode(Value value, Node* parent)
+	static Node* allocateNode(Value value, Node* parent, AllocatorType allocator)
 	out (result)
 	{
 		assert (result.left is null);
@@ -377,9 +393,11 @@ private:
 	{
 		import core.memory : GC;
 		import std.experimental.allocator : make;
-		import std.experimental.allocator.mallocator : Mallocator;
 
-		Node* n = make!Node(Mallocator.instance);
+		static if (stateSize!Allocator == 0)
+			Node* n = make!Node(Allocator.instance);
+		else
+			Node* n = make!Node(allocator);
 		n.parent = parent;
 		n.markUsed(0);
 		n.values[0] = cast(Value) value;
@@ -388,7 +406,7 @@ private:
 		return n;
 	}
 
-	static void deallocateNode(ref Node* n)
+	static void deallocateNode(ref Node* n, AllocatorType allocator)
 	in
 	{
 		assert (n !is null);
@@ -396,12 +414,19 @@ private:
 	body
 	{
 		import std.experimental.allocator : dispose;
-		import std.experimental.allocator.mallocator : Mallocator;
 		import core.memory : GC;
+
+		if (n.left !is null)
+			deallocateNode(n.left, allocator);
+		if (n.right !is null)
+			deallocateNode(n.right, allocator);
 
 		static if (supportGC && shouldAddGCRange!T)
 			GC.removeRange(n);
-		dispose(Mallocator.instance, n);
+		static if (stateSize!Allocator == 0)
+			dispose(Allocator.instance, n);
+		else
+			dispose(allocator, n);
 		n = null;
 	}
 
@@ -409,14 +434,6 @@ private:
 	static assert (Node.sizeof <= cacheLineSize);
 	static struct Node
 	{
-		~this()
-		{
-			if (left !is null)
-				deallocateNode(left);
-			if (right !is null)
-				deallocateNode(right);
-		}
-
 		private size_t nextAvailableIndex() const nothrow pure
 		{
 			import core.bitop : bsf;
@@ -489,7 +506,7 @@ private:
 			return 0;
 		}
 
-		bool insert(T value, ref Node* root)
+		bool insert(T value, ref Node* root, AllocatorType allocator)
 		in
 		{
 			static if (isPointer!T || is (T == class))
@@ -519,13 +536,13 @@ private:
 			{
 				if (left is null)
 				{
-					left = allocateNode(cast(Value) value, &this);
+					left = allocateNode(cast(Value) value, &this, allocator);
 					calcHeight();
 					return true;
 				}
-				bool b = left.insert(value, root);
+				bool b = left.insert(value, root, allocator);
 				if (imbalanced() == -1)
-					rotateRight(root);
+					rotateRight(root, allocator);
 				calcHeight();
 				return b;
 			}
@@ -533,13 +550,13 @@ private:
 			{
 				if (right is null)
 				{
-					right = allocateNode(value, &this);
+					right = allocateNode(value, &this, allocator);
 					calcHeight();
 					return true;
 				}
-				bool b = right.insert(value, root);
+				bool b = right.insert(value, root, allocator);
 				if (imbalanced() == 1)
-					rotateLeft(root);
+					rotateLeft(root, allocator);
 				calcHeight();
 				return b;
 			}
@@ -553,48 +570,49 @@ private:
 			if (right is null)
 			{
 				values[] = temp[0 .. $ - 1];
-				right = allocateNode(temp[$ - 1], &this);
+				right = allocateNode(temp[$ - 1], &this, allocator);
 				return true;
 			}
 			if (left is null)
 			{
 				values[] = temp[1 .. $];
-				left = allocateNode(temp[0], &this);
+				left = allocateNode(temp[0], &this, allocator);
 				return true;
 			}
 			if (right.height < left.height)
 			{
 				values[] = temp[0 .. $ - 1];
-				bool b = right.insert(temp[$ - 1], root);
+				bool b = right.insert(temp[$ - 1], root, allocator);
 				if (imbalanced() == 1)
-					rotateLeft(root);
+					rotateLeft(root, allocator);
 				calcHeight();
 				return b;
 			}
 			values[] = temp[1 .. $];
-			bool b = left.insert(temp[0], root);
+			bool b = left.insert(temp[0], root, allocator);
 			if (imbalanced() == -1)
-				rotateRight(root);
+				rotateRight(root, allocator);
 			calcHeight();
 			return b;
 		}
 
-		bool remove(Value value, ref Node* n, void delegate(T) cleanup = null)
+		bool remove(Value value, ref Node* n, AllocatorType allocator,
+			void delegate(T) cleanup = null)
 		{
 			import std.range : assumeSorted;
 			assert (!isEmpty());
 			if (isFull() && _less(value, values[0]))
 			{
-				bool r = left !is null && left.remove(value, left, cleanup);
+				bool r = left !is null && left.remove(value, left, allocator, cleanup);
 				if (left.isEmpty())
-					deallocateNode(left);
+					deallocateNode(left, allocator);
 				return r;
 			}
 			if (isFull() && _less(values[$ - 1], value))
 			{
-				bool r = right !is null && right.remove(value, right, cleanup);
+				bool r = right !is null && right.remove(value, right, allocator, cleanup);
 				if (right.isEmpty())
-					deallocateNode(right);
+					deallocateNode(right, allocator);
 				return r;
 			}
 			size_t i = nextAvailableIndex();
@@ -620,9 +638,9 @@ private:
 				temp[0 .. l] = values[0 .. l];
 				temp[l .. $] = values[l + 1 .. $];
 				values[0 .. $ - 1] = temp[];
-				values[$ - 1] = right.removeSmallest();
+				values[$ - 1] = right.removeSmallest(allocator);
 				if (right.isEmpty())
-					deallocateNode(right);
+					deallocateNode(right, allocator);
 			}
 			else if (left !is null)
 			{
@@ -630,14 +648,14 @@ private:
 				temp[0 .. l] = values[0 .. l];
 				temp[l .. $] = values[l + 1 .. $];
 				values[1 .. $] = temp[];
-				values[0] = left.removeLargest();
+				values[0] = left.removeLargest(allocator);
 				if (left.isEmpty())
-					deallocateNode(left);
+					deallocateNode(left, allocator);
 			}
 			return true;
 		}
 
-		Value removeSmallest()
+		Value removeSmallest(AllocatorType allocator)
 		in
 		{
 			assert (!isEmpty());
@@ -655,22 +673,22 @@ private:
 			}
 			if (left !is null)
 			{
-				auto r = left.removeSmallest();
+				auto r = left.removeSmallest(allocator);
 				if (left.isEmpty())
-					deallocateNode(left);
+					deallocateNode(left, allocator);
 				return r;
 			}
 			Value r = values[0];
 			Value[nodeCapacity - 1] temp = void;
 			temp[] = values[1 .. $];
 			values[0 .. $ - 1] = temp[];
-			values[$ - 1] = right.removeSmallest();
+			values[$ - 1] = right.removeSmallest(allocator);
 			if (right.isEmpty())
-				deallocateNode(right);
+				deallocateNode(right, allocator);
 			return r;
 		}
 
-		Value removeLargest()
+		Value removeLargest(AllocatorType allocator)
 		in
 		{
 			assert (!isEmpty());
@@ -691,22 +709,22 @@ private:
 			}
 			if (right !is null)
 			{
-				auto r = right.removeLargest();
+				auto r = right.removeLargest(allocator);
 				if (right.isEmpty())
-					deallocateNode(right);
+					deallocateNode(right, allocator);
 				return r;
 			}
 			Value r = values[$ - 1];
 			Value[nodeCapacity - 1] temp = void;
 			temp[] = values[0 .. $ - 1];
 			values[1 .. $] = temp[];
-			values[0] = left.removeLargest();
+			values[0] = left.removeLargest(allocator);
 			if (left.isEmpty())
-				deallocateNode(left);
+				deallocateNode(left, allocator);
 			return r;
 		}
 
-		void rotateLeft(ref Node* root)
+		void rotateLeft(ref Node* root, AllocatorType allocator)
 		{
 			Node* newRoot = void;
 			if (right.left !is null && right.right is null)
@@ -731,10 +749,10 @@ private:
 				newRoot.left = &this;
 				this.parent = newRoot;
 			}
-			cleanup(newRoot, root);
+			cleanup(newRoot, root, allocator);
 		}
 
-		void rotateRight(ref Node* root)
+		void rotateRight(ref Node* root, AllocatorType allocator)
 		{
 			Node* newRoot = void;
 			if (left.right !is null && left.left is null)
@@ -759,10 +777,10 @@ private:
 				newRoot.right = &this;
 				this.parent = newRoot;
 			}
-			cleanup(newRoot, root);
+			cleanup(newRoot, root, allocator);
 		}
 
-		void cleanup(Node* newRoot, ref Node* root)
+		void cleanup(Node* newRoot, ref Node* root, AllocatorType allocator)
 		{
 			if (newRoot.parent !is null)
 			{
@@ -773,14 +791,14 @@ private:
 			}
 			else
 				root = newRoot;
-			newRoot.fillFromChildren(root);
+			newRoot.fillFromChildren(root, allocator);
 			if (newRoot.left !is null)
 			{
-				newRoot.left.fillFromChildren(root);
+				newRoot.left.fillFromChildren(root, allocator);
 			}
 			if (newRoot.right !is null)
 			{
-				newRoot.right.fillFromChildren(root);
+				newRoot.right.fillFromChildren(root, allocator);
 			}
 			if (newRoot.left !is null)
 				newRoot.left.calcHeight();
@@ -789,21 +807,21 @@ private:
 			newRoot.calcHeight();
 		}
 
-		void fillFromChildren(ref Node* root)
+		void fillFromChildren(ref Node* root, AllocatorType allocator)
 		{
 			while (!isFull())
 			{
 				if (left !is null)
 				{
-					insert(left.removeLargest(), root);
+					insert(left.removeLargest(allocator), root, allocator);
 					if (left.isEmpty())
-						deallocateNode(left);
+						deallocateNode(left, allocator);
 				}
 				else if (right !is null)
 				{
-					insert(right.removeSmallest(), root);
+					insert(right.removeSmallest(allocator), root, allocator);
 					if (right.isEmpty())
-						deallocateNode(right);
+						deallocateNode(right, allocator);
 				}
 				else
 					return;
@@ -838,6 +856,7 @@ private:
 		size_t registry = (cast(size_t) 1) << (size_t.sizeof * 4);
 	}
 
+	AllocatorType allocator;
 	size_t _length = 0;
 	Node* root = null;
 }
@@ -889,7 +908,7 @@ unittest
 	}
 
 	{
-		TTree!(int, true) kt;
+		TTree!(int, Mallocator, true) kt;
 		assert (kt.insert(1));
 		assert (kt.length == 1);
 		assert (kt.insert(1));
@@ -945,7 +964,7 @@ unittest
 	}
 
 	{
-		TTree!(string, true) strings;
+		TTree!(string, Mallocator, true) strings;
 		assert (strings.insert("b"));
 		assert (strings.insert("c"));
 		assert (strings.insert("a"));
@@ -972,7 +991,7 @@ unittest
 			}
 		}
 
-		TTree!(S*, true) stringTree;
+		TTree!(S*, Mallocator, true) stringTree;
 		auto one = S("offset");
 		stringTree.insert(&one);
 		auto two = S("object");
@@ -991,7 +1010,7 @@ unittest
 			int x;
 			int y;
 		}
-		TTree!(TestStruct*, false) tsTree;
+		TTree!(TestStruct*) tsTree;
 		static assert (isInputRange!(typeof(tsTree[])));
 		foreach (i; 0 .. 100)
 			assert(tsTree.insert(new TestStruct(i, i * 2)));
@@ -1062,7 +1081,7 @@ unittest
 			}
 		}
 
-		TTree!(ABC, true) tree;
+		TTree!(ABC, Mallocator, true) tree;
 		foreach (i; 0 .. 10)
 			tree.insert(ABC(i));
 		tree.insert(ABC(15));
@@ -1093,5 +1112,23 @@ unittest
 			assert(!ints3.equalRange(i).empty);
 		foreach (i; iota(0, 1_000_000).filter!(a => a % 2 == 1))
 			assert(ints3.equalRange(i).empty);
+	}
+
+	{
+		import std.experimental.allocator.building_blocks.free_list : FreeList;
+		import std.experimental.allocator.building_blocks.allocator_list : AllocatorList;
+		import std.experimental.allocator.building_blocks.region : Region;
+		import std.experimental.allocator.building_blocks.stats_collector : StatsCollector;
+		import std.stdio : stdout;
+
+		StatsCollector!(FreeList!(AllocatorList!(a => Region!(Mallocator)(1024 * 1024)),
+			64)) allocator;
+		auto ints4 = TTree!(int, typeof(&allocator))(&allocator);
+		foreach (i; 0 .. 10_000)
+			ints4.insert(i);
+		assert(walkLength(ints4[]) == 10_000);
+		destroy(ints4);
+		assert(allocator.numAllocate == allocator.numDeallocate);
+		assert(allocator.bytesUsed == 0);
 	}
 }

--- a/src/containers/unrolledlist.d
+++ b/src/containers/unrolledlist.d
@@ -8,7 +8,6 @@
 module containers.unrolledlist;
 
 private import std.experimental.allocator.mallocator : Mallocator;
-private import std.experimental.allocator.common : stateSize;
 
 /**
  * Unrolled Linked List.
@@ -26,6 +25,8 @@ private import std.experimental.allocator.common : stateSize;
 struct UnrolledList(T, Allocator = Mallocator, bool supportGC = true, size_t cacheLineSize = 64)
 {
 	this(this) @disable;
+
+	private import std.experimental.allocator.common : stateSize;
 
 	static if (stateSize!Allocator != 0)
 	{
@@ -407,15 +408,12 @@ private:
 		fullBits, shouldNullSlot;
 	import containers.internal.storage_type : ContainerStorageType;
 	import containers.internal.element_type : ContainerElementType;
+	private import containers.internal.mixins : AllocatorState;
 
 	Node* _back;
 	Node* _front;
 	size_t _length;
-
-	static if (stateSize!Allocator == 0)
-		alias allocator = Allocator.instance;
-	else
-		Allocator allocator;
+	mixin AllocatorState!Allocator;
 
 	Node* allocateNode(T item)
 	{

--- a/test/compile_test.d
+++ b/test/compile_test.d
@@ -1,11 +1,12 @@
+import containers.dynamicarray;
 import containers.hashmap;
 import containers.hashset;
-import containers.unrolledlist;
 import containers.openhashset;
 import containers.simdset;
 import containers.slist;
 import containers.treemap;
 import containers.ttree;
+import containers.unrolledlist;
 
 private void testContainerSingle(alias Container)()
 {
@@ -221,6 +222,8 @@ private void testContainerDoubleRef(alias Container)()
 
 private void checkSliceFunctionality(Type, Container)(ref Container container)
 {
+	import std.array : front;
+
 	auto r = container[];
 	static assert(is(typeof(r.front()) == Type));
 	static assert(is(typeof(container.length) == size_t));
@@ -229,7 +232,7 @@ private void checkSliceFunctionality(Type, Container)(ref Container container)
 
 private void checkIndexFunctionality(Type, KeyType, Container)(ref Container container)
 {
-	auto v = container[KeyType.init];
+	static assert(__traits(compiles, {container[KeyType.init];}));
 	static assert(is(typeof(container[KeyType.init]) == Type));
 	static assert(is(typeof(container.length) == size_t));
 	assert(container.length == 0);
@@ -243,7 +246,8 @@ unittest
 	testContainerSingle!(HashSet)();
 	testContainerSingle!(UnrolledList)();
 	testContainerSingle!(OpenHashSet)();
-//	testContainerSingle!(SimdSet)();
+	testContainerSingle!(SimdSet)();
 	testContainerSingle!(SList)();
 	testContainerSingle!(TTree)();
+	testContainerSingle!(DynamicArray)();
 }

--- a/test/external_allocator_test.d
+++ b/test/external_allocator_test.d
@@ -1,0 +1,68 @@
+module external_allocator_test;
+
+import containers.dynamicarray;
+import containers.hashmap;
+import containers.hashset;
+import containers.immutablehashset;
+import containers.openhashset;
+import containers.simdset;
+import containers.slist;
+import containers.treemap;
+import containers.ttree;
+import containers.unrolledlist;
+import std.experimental.allocator.building_blocks.free_list : FreeList;
+import std.experimental.allocator.building_blocks.allocator_list : AllocatorList;
+import std.experimental.allocator.building_blocks.region : Region;
+import std.experimental.allocator.building_blocks.stats_collector : StatsCollector;
+import std.stdio : stdout;
+import std.algorithm.iteration : walkLength;
+import std.meta : AliasSeq;
+
+// Chosen for a very important and completely undocumented reason
+private enum VERY_SPECIFIC_NUMBER = 371;
+
+private void testSingle(alias Container, Allocator)(Allocator allocator)
+{
+	auto intMap = Container!(int, Allocator)(allocator);
+	foreach (i; 0 .. VERY_SPECIFIC_NUMBER)
+		intMap.insert(i);
+	assert(intMap.length == VERY_SPECIFIC_NUMBER);
+}
+
+private void testDouble(alias Container, Allocator)(Allocator allocator)
+{
+	auto intMap = Container!(int, int, Allocator)(allocator);
+	foreach (i; 0 .. VERY_SPECIFIC_NUMBER)
+		intMap[i] = VERY_SPECIFIC_NUMBER - i;
+	assert(intMap.length == VERY_SPECIFIC_NUMBER);
+}
+
+alias SingleContainers = AliasSeq!(DynamicArray,  HashSet,  /+ImmutableHashSet,+/
+OpenHashSet, SimdSet, SList, TTree, UnrolledList);
+
+alias DoubleContainers = AliasSeq!(HashMap, TreeMap);
+
+alias AllocatorType = StatsCollector!(
+	FreeList!(AllocatorList!(a => Region!(Mallocator)(1024 * 1024), Mallocator), 64));
+
+unittest
+{
+	foreach (C; SingleContainers)
+	{
+		AllocatorType allocator;
+		testSingle!(C, AllocatorType*)(&allocator);
+		assert(allocator.numAllocate > 0 || allocator.numReallocate > 0,
+			"No allocations happened for " ~ C.stringof);
+		assert(allocator.numAllocate == allocator.numDeallocate || allocator.numReallocate > 0);
+		assert(allocator.bytesUsed == 0);
+	}
+	foreach (C; DoubleContainers)
+	{
+		AllocatorType allocator;
+		testDouble!(C, AllocatorType*)(&allocator);
+		assert(allocator.numAllocate > 0 || allocator.numReallocate > 0,
+			"No allocations happened for " ~ C.stringof);
+		assert(allocator.numAllocate == allocator.numDeallocate || allocator.numReallocate > 0);
+		assert(allocator.bytesUsed == 0);
+	}
+}

--- a/test/makefile
+++ b/test/makefile
@@ -3,12 +3,17 @@
 SRC=$(shell find ../src/ -name "*.d") $(shell find ../experimental_allocator -name "*.d")
 FLAGS=-unittest -main -g -cov -I../src/ -debug -wi
 
-test: compile_test
+test: compile_test external_allocator_test
 	dmd $(FLAGS) $(SRC) -oftests
 	./tests
+	./compile_test
+	./external_allocator_test
 
-compile_test:
+compile_test: compile_test.d
 	dmd $(FLAGS) compile_test.d $(SRC) -ofcompile_test
+
+external_allocator_test: external_allocator_test.d
+	dmd $(FLAGS) external_allocator_test.d $(SRC) -ofexternal_allocator_test
 
 looptest: looptest.d
 	dmd looptest.d -inline -O -release \


### PR DESCRIPTION
This pull allows the containers to be templated on an allocator type instead of always using malloc/free. The containers still default to malloc (Mallocator). Each container checks to see if the allocator it was instantiated with has a size greater than zero. Allocators such as Mallocator where everything is static do not cause the container to be any larger than it previously was, but other allocator types cause the containers to be larger by the size of one pointer.

There is a new test case (external_allocator_test.d) that instantiates all the containers with a stats collecting allocator, inserts some elements, and checks that there are no memory problems.

I also added the rest of the containers to the element type test.