### PR TITLE
return reference in unrolledlist.range.front

### DIFF
--- a/src/containers/hashmap.d
+++ b/src/containers/hashmap.d
@@ -491,6 +491,8 @@ unittest
 	hm["one"] = 1;
 	assert (hm.length == 1);
 	assert (hm["one"] == 1);
+	hm["one"] = 2;
+	assert (hm["one"] == 2);
 	foreach (i; 0 .. 1000)
 	{
 		hm[randomUUID().toString] = i;

--- a/src/containers/unrolledlist.d
+++ b/src/containers/unrolledlist.d
@@ -358,9 +358,9 @@ struct UnrolledList(T, Allocator = Mallocator,
 			}
 		}
 
-		ET front() const @property @trusted @nogc
+		ref ET front() const @property @trusted @nogc
 		{
-			return cast(T) current.items[index];
+			return *(cast(T*) &current.items[index]);
 		}
 
 		void popFront() nothrow pure @safe


### PR DESCRIPTION
hashmap.insert trys to modify item.value through a ref loop variable.
But unrolledlist.range.front doesn't return a ref, so what is actually
changed is just a variable on stack.

